### PR TITLE
fix: add continue-on-error to draft conversion job

### DIFF
--- a/.github/workflows/ci-python-template.yml
+++ b/.github/workflows/ci-python-template.yml
@@ -105,6 +105,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [pre-commit, test]
     if: failure() && github.event_name == 'pull_request'
+    continue-on-error: true
     permissions:
       pull-requests: write
     steps:


### PR DESCRIPTION
Makes the convert-to-draft job resilient to GitHub tier restrictions. The convertPullRequestToDraft mutation is restricted to Pro/Team/Enterprise plans, causing unnecessary CI failures on Free tier organization accounts.