### PR TITLE
feat(ci): Intelligent CI/CD — uv caching, draft fix, path filtering

### DIFF
--- a/.github/workflows/PATH_FILTERING.md
+++ b/.github/workflows/PATH_FILTERING.md
@@ -1,0 +1,92 @@
+# CI Path Filtering — Caller Examples
+
+These example workflows demonstrate how repositories should invoke
+the shared CI templates with **path filtering** to minimize CI costs
+per the **Economic Prime Directive**.
+
+## Python Repository Example
+
+```yaml
+# .github/workflows/ci.yml
+name: CI
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.antigravity/**'
+      - '.specify/**'
+      - 'LICENSE'
+      - '.gitignore'
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.antigravity/**'
+      - '.specify/**'
+      - 'LICENSE'
+      - '.gitignore'
+
+jobs:
+  ci:
+    uses: vindicta-platform/.github/.github/workflows/ci-python-template.yml@main
+```
+
+## Node.js Repository Example
+
+```yaml
+# .github/workflows/ci.yml
+name: CI
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.antigravity/**'
+      - '.specify/**'
+      - 'LICENSE'
+      - '.gitignore'
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.antigravity/**'
+      - '.specify/**'
+      - 'LICENSE'
+      - '.gitignore'
+
+jobs:
+  ci:
+    uses: vindicta-platform/.github/.github/workflows/ci-node-template.yml@main
+```
+
+## Standard `paths-ignore` List
+
+All repositories **MUST** include the following paths-ignore to comply
+with the Economic Prime Directive:
+
+```yaml
+paths-ignore:
+  - '**.md'           # All markdown files
+  - 'docs/**'         # Documentation directory
+  - '.antigravity/**' # Agent context artifacts
+  - '.specify/**'     # SDD specification bundles
+  - 'LICENSE'         # License file
+  - '.gitignore'      # Git ignore rules
+```
+
+## Notes
+
+- Path filtering is applied at the **caller** level, not in the
+  reusable template, because `workflow_call` does not support
+  `paths-ignore` triggers directly.
+- Repos with **mandatory branch protection checks** should use
+  step-level conditionals instead of job-level `if:` to avoid
+  blocking merges on docs-only PRs (see ci-python-template.yml
+  for the `check-python` pattern).

--- a/.github/workflows/ci-node-template.yml
+++ b/.github/workflows/ci-node-template.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Check for pre-commit config
         id: check-config
         run: |
@@ -23,12 +23,12 @@ jobs:
             echo "has_config=false" >> $GITHUB_OUTPUT
             echo "::notice::No .pre-commit-config.yaml found, skipping pre-commit checks"
           fi
-      
+
       - uses: actions/setup-python@v5
         if: steps.check-config.outputs.has_config == 'true'
         with:
           python-version: '3.11'
-      
+
       - uses: pre-commit/action@v3.0.1
         if: steps.check-config.outputs.has_config == 'true'
         with:
@@ -38,33 +38,41 @@ jobs:
     name: Node.js Tests
     runs-on: ubuntu-latest
     needs: [pre-commit]
-    
+
     steps:
       - uses: actions/checkout@v4
-      
+
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
-      
+
       - name: Install dependencies
         run: npm ci
-      
+
       - name: Lint
         run: npm run lint --if-present
         continue-on-error: true
-      
+
       - name: Type check
         run: npm run typecheck --if-present
         continue-on-error: true
-      
+
+      - name: Run unit tests first (fail-fast)
+        run: npm run test:unit --if-present
+
       - name: Install Playwright browsers
         run: npx playwright install --with-deps
         if: hashFiles('playwright.config.*') != ''
-      
-      - name: Run tests
+
+      - name: Run e2e tests
+        run: npm run test:e2e --if-present
+        if: hashFiles('playwright.config.*') != ''
+
+      - name: Run tests (fallback)
         run: npm test
-      
+        if: hashFiles('playwright.config.*') == ''
+
       - name: Upload test artifacts
         uses: actions/upload-artifact@v4
         if: failure()
@@ -79,6 +87,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [pre-commit, test]
     if: failure() && github.event_name == 'pull_request'
+    continue-on-error: true
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/ci-python-template.yml
+++ b/.github/workflows/ci-python-template.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Check for pre-commit config
         id: check-config
         run: |
@@ -23,12 +23,12 @@ jobs:
             echo "has_config=false" >> $GITHUB_OUTPUT
             echo "::notice::No .pre-commit-config.yaml found, skipping pre-commit checks"
           fi
-      
+
       - uses: actions/setup-python@v5
         if: steps.check-config.outputs.has_config == 'true'
         with:
           python-version: '3.11'
-      
+
       - uses: pre-commit/action@v3.0.1
         if: steps.check-config.outputs.has_config == 'true'
         with:
@@ -42,10 +42,10 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.11', '3.12']
-    
+
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Check for Python source files
         id: check-python
         run: |
@@ -55,29 +55,40 @@ jobs:
             echo "has_python=false" >> $GITHUB_OUTPUT
             echo "::notice::No Python source files found, skipping tests"
           fi
-      
+
       - uses: actions/setup-python@v5
         if: steps.check-python.outputs.has_python == 'true'
         with:
           python-version: ${{ matrix.python-version }}
-      
+
       - uses: astral-sh/setup-uv@v4
         if: steps.check-python.outputs.has_python == 'true'
-      
+
+      - name: Cache uv dependencies
+        if: steps.check-python.outputs.has_python == 'true'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/uv
+            .venv
+          key: uv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/pyproject.toml', '**/uv.lock') }}
+          restore-keys: |
+            uv-${{ runner.os }}-${{ matrix.python-version }}-
+
       - name: Install dependencies
         if: steps.check-python.outputs.has_python == 'true'
         run: uv sync --dev
-      
+
       - name: Lint with ruff
         if: steps.check-python.outputs.has_python == 'true'
         run: uv run ruff check src/ --output-format=github
         continue-on-error: true
-      
+
       - name: Type check with mypy
         if: steps.check-python.outputs.has_python == 'true'
         run: uv run mypy src/ --ignore-missing-imports
         continue-on-error: true
-      
+
       - name: Check for tests directory
         if: steps.check-python.outputs.has_python == 'true'
         id: check-tests
@@ -88,11 +99,11 @@ jobs:
             echo "has_tests=false" >> $GITHUB_OUTPUT
             echo "::notice::No tests directory found, skipping test execution"
           fi
-      
+
       - name: Run tests with coverage
         if: steps.check-python.outputs.has_python == 'true' && steps.check-tests.outputs.has_tests == 'true'
         run: uv run pytest tests/ -v --tb=short --cov=src --cov-report=xml
-      
+
       - name: Upload coverage
         uses: actions/upload-artifact@v4
         if: matrix.python-version == '3.12' && steps.check-tests.outputs.has_tests == 'true'

--- a/workflows/ci-pester-template.yml
+++ b/workflows/ci-pester-template.yml
@@ -15,7 +15,7 @@ jobs:
       should-test: ${{ steps.check-config.outputs.has_config != 'true' || success() }}
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Check for pre-commit config
         id: check-config
         run: |
@@ -25,12 +25,12 @@ jobs:
             echo "has_config=false" >> $GITHUB_OUTPUT
             echo "::notice::No .pre-commit-config.yaml found, skipping pre-commit checks"
           fi
-      
+
       - uses: actions/setup-python@v5
         if: steps.check-config.outputs.has_config == 'true'
         with:
           python-version: '3.11'
-      
+
       - uses: pre-commit/action@v3.0.1
         if: steps.check-config.outputs.has_config == 'true'
         with:
@@ -40,10 +40,10 @@ jobs:
     name: Pester Tests
     runs-on: windows-latest
     needs: [pre-commit]
-    
+
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Run Pester Tests
         shell: powershell
         run: |
@@ -55,7 +55,7 @@ jobs:
           }
           $result = Invoke-Pester @config
           if ($result.FailedCount -gt 0) { exit 1 }
-      
+
       - name: Upload Test Results
         uses: actions/upload-artifact@v4
         if: always()
@@ -68,6 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [pre-commit, test]
     if: failure() && github.event_name == 'pull_request'
+    continue-on-error: true
     permissions:
       pull-requests: write
     steps:


### PR DESCRIPTION
## DI-1: Intelligent CI/CD Pipelines

Part of [v2.0 Release Plan #5](https://github.com/vindicta-platform/.github/issues/5) | Resolves #6

### Changes

**`ci-python-template.yml`**:
- ✅ Add `actions/cache@v4` for `uv` dependencies (`~/.cache/uv` and `.venv`)
- ✅ Cache keyed on `pyproject.toml` and `uv.lock` with OS/Python fallback

**`ci-node-template.yml`**:
- ✅ Add `continue-on-error: true` to `convert-to-draft` job (was missing vs Python)
- ✅ Restructure tests for **fail-fast**: unit tests run before Playwright install
- ✅ Add `test:unit` and `test:e2e` script support with `--if-present`

**`ci-pester-template.yml`**:
- ✅ Add `continue-on-error: true` to `convert-to-draft` job

**`PATH_FILTERING.md`** (NEW):
- ✅ Standard `paths-ignore` list for Economic Prime Directive compliance
- ✅ Example caller workflows for Python and Node.js repos
- ✅ Notes on branch protection + docs-only PR handling

### Cost Impact
- uv caching: ~30-60s saved per Python CI run
- Fail-fast unit tests: avoid Playwright install on early failures (~2-3 min saved)
- Path filtering docs: enables per-repo cost savings on docs-only merges

### Next Steps
Individual repo rollout will follow in separate PRs.