### PR TITLE
feat: add stale issue & PR janitor

### DIFF
--- a/.github/workflows/stale-janitor.yml
+++ b/.github/workflows/stale-janitor.yml
@@ -1,0 +1,41 @@
+name: Stale Issue & PR Janitor
+
+on:
+  schedule:
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: >
+            🧹 This issue has been inactive for 30 days.
+            It will be automatically closed in 14 days unless there is new activity.
+            If this is still relevant, please leave a comment or update the issue.
+          stale-pr-message: >
+            🧹 This pull request has been inactive for 14 days.
+            Please rebase, address feedback, or close if no longer needed.
+            It will be automatically closed in 7 days without activity.
+          close-issue-message: >
+            🔒 This issue was closed due to inactivity.
+            Feel free to reopen if it is still relevant.
+          close-pr-message: >
+            🔒 This PR was closed due to inactivity.
+            Feel free to reopen and rebase if the changes are still needed.
+          days-before-stale: 30
+          days-before-close: 14
+          days-before-pr-stale: 14
+          days-before-pr-close: 7
+          exempt-issue-labels: 'priority:critical,blocked,epic,pinned'
+          exempt-pr-labels: 'blocked,do-not-close'
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          operations-per-run: 50
+          remove-stale-when-updated: true


### PR DESCRIPTION
## Summary
Adds `stale-janitor.yml` — an org-wide scheduled workflow to manage stale issues and PRs.

## Behavior
- Issues inactive 30 days → marked stale → closed after 14 more days
- PRs inactive 14 days → marked stale → closed after 7 more days
- Exempt labels: `priority:critical`, `blocked`, `epic`, `pinned`
- Runs daily at 9 AM UTC + manual dispatch