### PR TITLE
fix: label-sync graceful degradation

### DIFF
--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -21,35 +21,53 @@ jobs:
       - name: Sync labels to all repos
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.ORG_ADMIN_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
             const labels = JSON.parse(fs.readFileSync('.github/labels.json', 'utf8'));
 
-            const repos = await github.paginate(github.rest.repos.listForOrg, {
-              org: 'vindicta-platform', type: 'public'
-            });
+            let repos;
+            try {
+              repos = await github.paginate(github.rest.repos.listForOrg, {
+                org: 'vindicta-platform', type: 'public'
+              });
+            } catch (e) {
+              // Fallback: if no org access, sync to current repo only
+              core.warning(`Cannot list org repos (${e.message}). Syncing to current repo only. Set ORG_ADMIN_TOKEN secret for cross-repo sync.`);
+              repos = [{ name: context.repo.repo, archived: false }];
+            }
 
             let synced = 0;
+            let errors = 0;
             for (const repo of repos) {
               if (repo.archived) continue;
               core.info(`Syncing labels to ${repo.name}...`);
 
               for (const label of labels) {
                 try {
-                  await github.rest.issues.getLabel({
-                    owner: 'vindicta-platform', repo: repo.name, name: label.name
-                  });
-                  await github.rest.issues.updateLabel({
-                    owner: 'vindicta-platform', repo: repo.name, name: label.name,
-                    color: label.color, description: label.description || ''
-                  });
-                } catch {
-                  await github.rest.issues.createLabel({
-                    owner: 'vindicta-platform', repo: repo.name, name: label.name,
-                    color: label.color, description: label.description || ''
-                  });
+                  try {
+                    await github.rest.issues.getLabel({
+                      owner: 'vindicta-platform', repo: repo.name, name: label.name
+                    });
+                    await github.rest.issues.updateLabel({
+                      owner: 'vindicta-platform', repo: repo.name, name: label.name,
+                      color: label.color, description: label.description || ''
+                    });
+                  } catch {
+                    await github.rest.issues.createLabel({
+                      owner: 'vindicta-platform', repo: repo.name, name: label.name,
+                      color: label.color, description: label.description || ''
+                    });
+                  }
+                } catch (e) {
+                  core.warning(`Failed to sync label "${label.name}" to ${repo.name}: ${e.message}`);
+                  errors++;
                 }
               }
               synced++;
             }
-            core.notice(`Synced ${labels.length} labels across ${synced} repos`);
+
+            const msg = `Synced ${labels.length} labels across ${synced} repos (${errors} errors)`;
+            core.notice(msg);
+            core.summary.addRaw(`### 🏷️ Label Sync\n\n${msg}\n\n> **Note:** For cross-repo sync, set an \`ORG_ADMIN_TOKEN\` secret with \`admin:org\` and \`repo\` scopes.`);
+            await core.summary.write();


### PR DESCRIPTION
Fixes the `Resource not accessible by integration` error. The `GITHUB_TOKEN` can't create labels on other repos. Now:
- Uses `ORG_ADMIN_TOKEN` secret if available for cross-repo sync
- Falls back gracefully to syncing the current repo only
- Wraps each label operation in try/catch to avoid hard failures
- Posts a setup note in the step summary